### PR TITLE
Get OS X screensaver working.

### DIFF
--- a/Tatami/Domestic Moire.xcodeproj/project.pbxproj
+++ b/Tatami/Domestic Moire.xcodeproj/project.pbxproj
@@ -19,6 +19,10 @@
 		57A593551C38CC2300DA28E3 /* logo.xxiivv.white.png in Resources */ = {isa = PBXBuildFile; fileRef = 57A593541C38CC2300DA28E3 /* logo.xxiivv.white.png */; };
 		57B4B65E1C4F470F00D3A226 /* DomesticView.h in Headers */ = {isa = PBXBuildFile; fileRef = 57B4B65D1C4F470F00D3A226 /* DomesticView.h */; };
 		57B4B6601C4F470F00D3A226 /* DomesticView.m in Sources */ = {isa = PBXBuildFile; fileRef = 57B4B65F1C4F470F00D3A226 /* DomesticView.m */; };
+		7DAAB92D1C50B6BA0007F9FA /* logo.xxiivv.white.png in Resources */ = {isa = PBXBuildFile; fileRef = 57A593541C38CC2300DA28E3 /* logo.xxiivv.white.png */; };
+		7DAAB9311C50B6FD0007F9FA /* ScreenSaverScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DAAB92E1C50B6FD0007F9FA /* ScreenSaverScene.swift */; };
+		7DAAB9321C50B6FD0007F9FA /* ScreenSaverSKView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DAAB92F1C50B6FD0007F9FA /* ScreenSaverSKView.swift */; };
+		7DAAB9331C50B6FD0007F9FA /* Tile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DAAB9301C50B6FD0007F9FA /* Tile.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -38,6 +42,9 @@
 		57B4B65D1C4F470F00D3A226 /* DomesticView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DomesticView.h; sourceTree = "<group>"; };
 		57B4B65F1C4F470F00D3A226 /* DomesticView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DomesticView.m; sourceTree = "<group>"; };
 		57B4B6611C4F470F00D3A226 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		7DAAB92E1C50B6FD0007F9FA /* ScreenSaverScene.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScreenSaverScene.swift; sourceTree = "<group>"; };
+		7DAAB92F1C50B6FD0007F9FA /* ScreenSaverSKView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScreenSaverSKView.swift; sourceTree = "<group>"; };
+		7DAAB9301C50B6FD0007F9FA /* Tile.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Tile.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -99,6 +106,9 @@
 			children = (
 				57B4B65D1C4F470F00D3A226 /* DomesticView.h */,
 				57B4B65F1C4F470F00D3A226 /* DomesticView.m */,
+				7DAAB92E1C50B6FD0007F9FA /* ScreenSaverScene.swift */,
+				7DAAB92F1C50B6FD0007F9FA /* ScreenSaverSKView.swift */,
+				7DAAB9301C50B6FD0007F9FA /* Tile.swift */,
 				57B4B6611C4F470F00D3A226 /* Info.plist */,
 			);
 			path = Domestic;
@@ -209,6 +219,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7DAAB92D1C50B6BA0007F9FA /* logo.xxiivv.white.png in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -229,7 +240,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7DAAB9311C50B6FD0007F9FA /* ScreenSaverScene.swift in Sources */,
+				7DAAB9321C50B6FD0007F9FA /* ScreenSaverSKView.swift in Sources */,
 				57B4B6601C4F470F00D3A226 /* DomesticView.m in Sources */,
+				7DAAB9331C50B6FD0007F9FA /* Tile.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -356,8 +370,10 @@
 			buildSettings = {
 				COMBINE_HIDPI_IMAGES = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
+				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
 				INFOPLIST_FILE = Domestic/Info.plist;
 				INSTALL_PATH = "$(HOME)/Library/Screen Savers";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.xxiivv.Domestic;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = saver;
@@ -368,8 +384,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				COMBINE_HIDPI_IMAGES = YES;
+				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
 				INFOPLIST_FILE = Domestic/Info.plist;
 				INSTALL_PATH = "$(HOME)/Library/Screen Savers";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.xxiivv.Domestic;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = saver;
@@ -404,6 +422,7 @@
 				57B4B6631C4F470F00D3A226 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/Tatami/Domestic/DomesticView.h
+++ b/Tatami/Domestic/DomesticView.h
@@ -7,7 +7,12 @@
 //
 
 #import <ScreenSaver/ScreenSaver.h>
+#import "Domestic-Swift.h"
+@import SpriteKit;
 
 @interface DomesticView : ScreenSaverView
+
+@property (strong) ScreenSaverSKView * spriteView;
+@property (strong) ScreenSaverScene * spriteScene;
 
 @end

--- a/Tatami/Domestic/DomesticView.m
+++ b/Tatami/Domestic/DomesticView.m
@@ -3,6 +3,7 @@
 //  Copyright © 2016 Devine Lu Linvega. All rights reserved.
 
 #import "DomesticView.h"
+#import "Domestic-Swift.h"
 
 @implementation DomesticView
 
@@ -10,10 +11,27 @@
 {
     self = [super initWithFrame:frame isPreview:isPreview];
     if (self) {
+        self.spriteView = [[ScreenSaverSKView alloc] initWithFrame:self.frame];
+        [self addSubview:self.spriteView];
+        self.spriteView.ignoresSiblingOrder = true;
+        self.spriteView.showsFPS = false;
+        self.spriteView.showsNodeCount = false;
+        self.spriteScene = [ScreenSaverScene new];
+        self.spriteScene.size = self.frame.size;
+        self.spriteScene.scaleMode = SKSceneScaleModeAspectFit;
+        self.spriteScene.backgroundColor = [SKColor blackColor];
+        [self.spriteView presentScene:self.spriteScene];
+        
         [self setAnimationTimeInterval:1/30.0];
     }
-	[[NSWorkspace sharedWorkspace] launchApplication: @"Domestic Moire"];
     return self;
+}
+
+-(void)setFrame:(NSRect)frame
+{
+    [super setFrame:frame];
+    self.spriteView.frame = self.frame;
+    self.spriteScene.size = self.frame.size;
 }
 
 - (void)startAnimation
@@ -33,6 +51,7 @@
 
 - (void)animateOneFrame
 {
+    [super animateOneFrame];
     return;
 }
 

--- a/Tatami/Domestic/ScreenSaverSKView.swift
+++ b/Tatami/Domestic/ScreenSaverSKView.swift
@@ -1,0 +1,17 @@
+//
+//  GameView.swift
+//  Screensavr
+//
+//  Created by Patrick Winchell on 1/19/16.
+//  Copyright © 2016 Patrick Winchell. All rights reserved.
+//
+
+import Cocoa
+import SpriteKit
+
+public class ScreenSaverSKView: SKView {
+    
+    // Ignore all input so the screensaver ends on any input
+    public override var acceptsFirstResponder: Bool { return false }
+    
+}

--- a/Tatami/Domestic/ScreenSaverScene.swift
+++ b/Tatami/Domestic/ScreenSaverScene.swift
@@ -1,0 +1,84 @@
+
+//  Created by Devine Lu Linvega on 2016-01-02.
+//  Copyright (c) 2016 Devine Lu Linvega. All rights reserved.
+
+import SpriteKit
+import Cocoa
+
+var rings:Int = 30
+
+public class ScreenSaverScene: SKScene
+{
+	let container = SKNode()
+    var image: SKNode?
+    var tiles = [Tile]()
+    
+    // Ignore all input so the screensaver ends on any input
+    public override var acceptsFirstResponder: Bool { return false }
+	
+    public override func didMoveToView(view: SKView)
+	{
+        self.resignFirstResponder()
+        self.userInteractionEnabled=false
+        removeChildrenInArray([container])
+		addChild(container)
+		
+		var count = 1
+		while count < rings {
+            let newTile = Tile(index:count, size: self.size)
+			container.addChild(newTile)
+            tiles.append(newTile)
+			count += 1
+		}
+        
+        if let image = self.getImage("logo.xxiivv.white")
+        {
+            let texture = SKTexture(image: image)
+            let node = SKSpriteNode(texture: texture)
+            self.image = node
+            self.addChild(node)
+            node.size.width = node.size.width / 2
+            node.size.height = node.size.height / 2
+            node.position = CGPoint(x: (node.size.width / 2) + 20,
+                y:  (node.size.height / 2) + 20)
+        }
+    }
+	
+//	override func mouseDown(theEvent: NSEvent)
+//	{
+//		mainView.exitFullScreenModeWithOptions(nil)
+//		NSApp.terminate(self)
+//	}
+	
+    public override func update(currentTime: CFTimeInterval)
+	{
+		for tile in tiles
+        {
+            tile.animate()
+        }
+        
+        // Fade the xxiivv logo to prevent burn-in
+        if let image = self.image
+        {
+            image.alpha = sin(CGFloat(currentTime * M_PI / 60.0))
+        }
+    }
+    
+    
+    // In the screensave environment getting an image is harder than it should be.
+    func getImage(name: String) -> NSImage?
+    {
+        if let image = NSImage(named: "logo.xxiivv.white")
+        {
+            return image
+        }
+        
+        let bundle = NSBundle(forClass: ScreenSaverScene.self)
+        if let path = bundle.pathForResource(name, ofType: "png")
+        {
+            return NSImage(contentsOfFile: path)
+        }
+        
+        return nil
+    }
+}

--- a/Tatami/Domestic/Tile.swift
+++ b/Tatami/Domestic/Tile.swift
@@ -1,0 +1,55 @@
+
+//  Created by Devine Lu Linvega on 2016-01-02.
+//  Copyright © 2016 Devine Lu Linvega. All rights reserved.
+
+import Foundation
+import SpriteKit
+
+class Tile: SKNode
+{
+	var sprite:SKShapeNode!
+	var time:CGFloat = 0
+	var index:Int = 0
+	var ratio:CGFloat = 0
+	
+    init( index:Int, size: NSSize)
+	{
+		super.init()
+		self.position = CGPoint(x: size.width/2, y: size.height/2)
+		self.index = index
+		
+		sprite = SKShapeNode(circleOfRadius: (size.height/100) * CGFloat(rings - index))
+		sprite.fillColor = index % 2 == 0 ? NSColor.whiteColor() : NSColor.blackColor()
+		sprite.strokeColor = NSColor.clearColor()
+		addChild(sprite)
+		
+		ratio = CGFloat(index)/CGFloat(rings)
+	}
+	
+	func animate()
+	{
+		let slow = sin(time * 0.0001)
+		let medium = sin(time * 0.001)
+		let fast = sin(time * ratio * (medium/10))/ratio * 20 * ratio * slow
+		
+		let wobble = ((sin(time * 0.01) * CGFloat(rings) ) + CGFloat(rings)) * 0.1
+		
+		sprite.position = CGPoint(x: 0, y: (10 * ratio) + (10 * wobble * ratio))
+		
+		zRotation = time * 0.025 + ratio * (wobble/2) + (slow * ratio) * (slow * wobble/medium)
+		sprite.xScale = 1 + (wobble * ratio * 0.1)
+		sprite.yScale = 1 + (wobble * ratio * 0.2 * ratio * wobble * 0.25)
+		
+		sprite.xScale += fast * 0.01 * ratio
+		sprite.yScale += fast * 0.01 * ratio
+		
+		sprite.zRotation = ( wobble * ratio * medium * wobble ) / ratio
+		
+		time += 1
+	}
+
+	required init?(coder aDecoder: NSCoder)
+	{
+	    fatalError("init(coder:) has not been implemented")
+	}
+}


### PR DESCRIPTION
- Properly include modified versions of the Domestic swift files.
- Change some build settings.
- Include XXIIVV logo as sprite that fades.
- Add code to get the screensaver to include a sprite kit view correctly.